### PR TITLE
1. use helper & logger provided by karma  2. write results synchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "jasmine": "^2.4.1"
   },
   "dependencies": {
-    "fun-map": "^3.3.1",
-    "writefile": "^0.2.8"
+    "fun-map": "^3.3.1"
   }
 }

--- a/spec/jsonResultReporter.spec.js
+++ b/spec/jsonResultReporter.spec.js
@@ -24,7 +24,9 @@ describe("JsonResultReporter", function() {
         return error;
       });
       this.helper = jasmine.createSpy('helper');
-      this.helper.mkdirIfNotExists = jasmine.createSpy('mkdirIfNotExists spy').and.callFake(function(dirStr, callback) {});
+      this.helper.mkdirIfNotExists = jasmine.createSpy('mkdirIfNotExists spy').and.callFake(function(dirStr, callback) {
+        callback();
+      });
       this.logger = jasmine.createSpy('logger');
       this.logger.create = jasmine.createSpy('create spy').and.callFake(function(loggerName) {});
     });

--- a/spec/jsonResultReporter.spec.js
+++ b/spec/jsonResultReporter.spec.js
@@ -24,11 +24,16 @@ describe("JsonResultReporter", function() {
         return error;
       });
       this.helper = jasmine.createSpy('helper');
-      this.helper.mkdirIfNotExists = jasmine.createSpy('mkdirIfNotExists spy').and.callFake(function(dirStr, callback) {
+      this.helper.mkdirIfNotExists = jasmine.createSpy('helper.mkdirIfNotExists spy').and.callFake(function(dirStr, callback) {
         callback();
       });
       this.logger = jasmine.createSpy('logger');
-      this.logger.create = jasmine.createSpy('create spy').and.callFake(function(loggerName) {});
+      log = jasmine.createSpy('log');
+      log.debug = jasmine.createSpy('log.debug spy').and.callFake(function(output) {});
+      log.warn = jasmine.createSpy('log.warn spy').and.callFake(function(output) {});
+      this.logger.create = jasmine.createSpy('logger.create spy').and.callFake(function(loggerName) {
+        return log;
+      });
     });
 
 

--- a/spec/jsonResultReporter.spec.js
+++ b/spec/jsonResultReporter.spec.js
@@ -23,13 +23,19 @@ describe("JsonResultReporter", function() {
       this.formatError = jasmine.createSpy('formatError').and.callFake(function(error) {
         return error;
       });
+      this.helper = jasmine.createSpy('helper');
+      function mkdirIfNotExists(dirStr, callback) {};
+      spyOn(this.helper, 'mkdirIfNotExists');
+      this.logger = jasmine.createSpy('logger');
+      function create(loggerName) {};
+      spyOn(this.logger, 'create');
     });
 
 
     it('should be instantiable', function() {
       var config = {};
 
-      var reporter = new JsonResultReporter(this.baseReporterDecorator, this.formatError, config);
+      var reporter = new JsonResultReporter(this.baseReporterDecorator, this.formatError, config, this.helper, this.logger);
 
       expect(reporter).toEqual(jasmine.any(Object));
       expect(this.baseReporterDecorator).toHaveBeenCalledTimes(1);
@@ -66,7 +72,7 @@ describe("JsonResultReporter", function() {
         };
 
 
-        var reporter = new JsonResultReporter(this.baseReporterDecorator, this.formatError, config);
+        var reporter = new JsonResultReporter(this.baseReporterDecorator, this.formatError, config, this.helper, this.logger);
         reporter.onBrowserError('test', ERROR_TEXT);
         reporter.onRunComplete();
 
@@ -78,7 +84,7 @@ describe("JsonResultReporter", function() {
           outputFile: this.tempTestDir + '/my/nested/path/report-file.json'
         };
 
-        var reporter = new JsonResultReporter(this.baseReporterDecorator, this.formatError, config);
+        var reporter = new JsonResultReporter(this.baseReporterDecorator, this.formatError, config, this.helper, this.logger);
         reporter.onBrowserError('test', ERROR_TEXT);
         reporter.onRunComplete();
 

--- a/spec/jsonResultReporter.spec.js
+++ b/spec/jsonResultReporter.spec.js
@@ -25,6 +25,9 @@ describe("JsonResultReporter", function() {
       });
       this.helper = jasmine.createSpy('helper');
       this.helper.mkdirIfNotExists = jasmine.createSpy('helper.mkdirIfNotExists spy').and.callFake(function(dirStr, callback) {
+        if (!fs.existsSync(dirStr)) {
+          fs.mkdirSync(dirStr);
+        }
         callback();
       });
       this.logger = jasmine.createSpy('logger');

--- a/spec/jsonResultReporter.spec.js
+++ b/spec/jsonResultReporter.spec.js
@@ -24,11 +24,9 @@ describe("JsonResultReporter", function() {
         return error;
       });
       this.helper = jasmine.createSpy('helper');
-      function mkdirIfNotExists(dirStr, callback) {};
-      spyOn(this.helper, 'mkdirIfNotExists');
+      this.helper.mkdirIfNotExists = jasmine.createSpy('mkdirIfNotExists spy').and.callFake(function(dirStr, callback) {});
       this.logger = jasmine.createSpy('logger');
-      function create(loggerName) {};
-      spyOn(this.logger, 'create');
+      this.logger.create = jasmine.createSpy('create spy').and.callFake(function(loggerName) {});
     });
 
 


### PR DESCRIPTION
There may be some cases that we want to deal with the generated test results file in gulp task. If the result file is written asynchronously, we may meet with some errors because the file is not ready yet. Just learn this idea from karma-coverage project.

Another change is: I have used the helper provided by karma instead of using writefile module.
