### PR TITLE
Write out both browser errors and results if both are provided.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var funMap = require('fun-map');
 var converter = require('./resultConverter');
 
 function writeOutput(config, output, helper, logger) {
@@ -53,12 +54,14 @@ var JsonResultReporter = function(baseReporterDecorator, formatError, config, he
   };
 
   this.onRunComplete = function() {
-    var output;
+    var output = {};
     if (this.errors.length) {
       output = converter.convertErrors(this.errors.map(logMessageFormater));
-    } else {
-      output = converter.convertResults(this.results);
     }
+    if (this.results.length) {
+      output = funMap.merge(output, converter.convertResults(this.results));
+    }
+
     writeOutput(config, output, helper, logger);
 
     this.clear();


### PR DESCRIPTION
Previously, any browser errors (e.g. disconnection) would prevent any results being logged.

For example, in the scenario where a disconnection error occurs, but karma retries and successfully runs specs (if `browserDisconnectTolerance` setting has positive value), the existing reporter only logs the browser error.

Jasmine test for logging both types has been added.
